### PR TITLE
add endpoints for single and multiple image uploads

### DIFF
--- a/src/cloudinary/cloudinary.controller.ts
+++ b/src/cloudinary/cloudinary.controller.ts
@@ -1,5 +1,12 @@
-import { Controller, Post, UseInterceptors, UploadedFile } from '@nestjs/common';
-import { FileInterceptor } from '@nestjs/platform-express';
+import {
+  Controller,
+  Post,
+  UseInterceptors,
+  UploadedFile,
+  UploadedFiles,
+  BadRequestException,
+} from '@nestjs/common';
+import { FileInterceptor, FilesInterceptor } from '@nestjs/platform-express';
 import { CloudinaryService } from './cloudinary.service';
 import { Express } from 'express';
 import * as multer from 'multer';
@@ -17,5 +24,23 @@ export class CloudinaryController {
 
     const result = await this.cloudinaryService.uploadImage(file);
     return result;
+  }
+
+  @Post('upload-multiple')
+  @UseInterceptors(
+    FilesInterceptor('files', 10, { storage: multer.memoryStorage() }),
+  )
+  async uploadMultipleImages(
+    @UploadedFiles() files: Express.Multer.File[],
+  ): Promise<any> {
+    if (!files || files.length === 0) {
+      throw new BadRequestException('No files provided');
+    }
+
+    const uploadPromises = files.map((file) =>
+      this.cloudinaryService.uploadImage(file),
+    );
+    const results = await Promise.all(uploadPromises);
+    return results;
   }
 }


### PR DESCRIPTION
- Added a new endpoint `/upload` to upload a single image.
- Created a new endpoint `/upload-multiple` to handle multiple image uploads (up to 10 images at once).
- Utilized `FileInterceptor` for single image upload and `FilesInterceptor` for multiple images.
- Included validation to handle cases where no files are provided.